### PR TITLE
feat: rename 'Work' to 'Work Projects' and 'Projects' to 'Side Projects'

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaibhav Bansal - Product Manager Portfolio</title>
-    <meta name="description" content="Product Manager with experience building user-centric products. View case studies, projects, and professional experience." />
+    <meta name="description" content="Product Manager with experience building user-centric products. View work, side projects, and professional experience." />
     <meta name="author" content="Vaibhav Bansal" />
 
     <meta property="og:title" content="Vaibhav Bansal - Product Manager Portfolio" />
-    <meta property="og:description" content="Product Manager with experience building user-centric products. View case studies, projects, and professional experience." />
+    <meta property="og:description" content="Product Manager with experience building user-centric products. View work, side projects, and professional experience." />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,10 +39,10 @@ const AppContent = () => {
                   <Route path="/" element={<Layout />}>
                     <Route index element={<Index />} />
                     <Route path="about" element={<About />} />
-                    <Route path="case-studies" element={<CaseStudies />} />
-                    <Route path="case-studies/:id" element={<CaseStudyDetail />} />
-                    <Route path="maker-projects" element={<MakerProjects />} />
-                    <Route path="maker-projects/:id" element={<ProjectDetail />} />
+                    <Route path="work-projects" element={<CaseStudies />} />
+                    <Route path="work-projects/:id" element={<CaseStudyDetail />} />
+                    <Route path="side-projects" element={<MakerProjects />} />
+                    <Route path="side-projects/:id" element={<ProjectDetail />} />
                     <Route path="writing" element={<Writing />} />
                     <Route path="resources" element={<Resources />} />
                     <Route path="*" element={<NotFound />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -130,21 +130,21 @@ const Footer = () => {
               
               {/* Work Section */}
               <div className="text-center">
-                <h4 className="text-sm font-medium text-foreground mb-2">Work</h4>
+                <h4 className="text-sm font-medium text-foreground mb-2">Work Projects</h4>
                 <nav className="flex flex-col space-y-2" aria-label="Work navigation">
                   <Link
-                    to="/case-studies"
-                    onClick={() => handleNavigationClick("/case-studies", location.pathname)}
+                    to="/work-projects"
+                    onClick={() => handleNavigationClick("/work-projects", location.pathname)}
                     className="text-sm text-muted-foreground hover:text-primary transition-colors w-fit mx-auto"
                   >
-                    Case Studies
+                    Work Projects
                   </Link>
                   <Link
-                    to="/maker-projects"
-                    onClick={() => handleNavigationClick("/maker-projects", location.pathname)}
+                    to="/side-projects"
+                    onClick={() => handleNavigationClick("/side-projects", location.pathname)}
                     className="text-sm text-muted-foreground hover:text-primary transition-colors w-fit mx-auto"
                   >
-                    AI Projects
+                    Side Projects
                   </Link>
                 </nav>
               </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -72,7 +72,7 @@ const Header = () => {
             className="text-xl font-bold gradient-text hover:opacity-80 transition-opacity"
             aria-label={`${portfolioConfig.personal.name} - Home`}
           >
-            🚀🔝
+            🏠🚀
           </Link>
 
           {/* Desktop Navigation */}

--- a/src/config/portfolio.json.test
+++ b/src/config/portfolio.json.test
@@ -79,12 +79,12 @@
       "href": "/about"
     },
     {
-      "name": "Case Studies",
-      "href": "/case-studies"
+      "name": "Work Projects",
+      "href": "/work-projects"
     },
     {
-      "name": "Projects",
-      "href": "/maker-projects"
+      "name": "Side Projects",
+      "href": "/side-projects"
     },
     {
       "name": "Writing",

--- a/src/config/portfolio.jsonc
+++ b/src/config/portfolio.jsonc
@@ -2,12 +2,12 @@
   "personal": {
     "name": "Vaibhav Bansal",
     "title": "Product Manager",
-    "tagline": "Building workflow-driven, scalable, and user-centric products",
+    "tagline": "Building user-centric, scalable and event-driven products",
     "location": "Ahmedabad, India",
     "email": "vbansal079@gmail.com",
     "phone": "+91-94281-81545",
     "resumeLink": "https://drive.google.com/file/d/1SHq0qLsAj4i7R8gxGp21_Wwb13GDuXg_/view?usp=drive_link",
-    "bio": "Product Manager with 2+ years of experience building onboarding journeys, self-serve platforms, and API-first products across fintech and automation. Specialized in workflow-driven experiences, adoption-focused releases, and AI-driven product thinking.",
+    "bio": "Product Manager (4 years' experience, 2+ as PM) who focuses on solving high-leverage product problems: reducing time-to-activation through delightful onboarding, unlocking recurring revenue via thoughtful subscription & billing flows, and scaling developer adoption with API-first approach. Lately I'm applying AI to improve automation and product decisioning.",
     "yearsExperience": 2,
     "currentRole": "Product Manager at Quicko",
     "domains": [
@@ -24,26 +24,26 @@
       "philosophy": {
         "userCentric": {
           "title": "User-Centric",
-          "description": "Design experiences that reduce friction and scale with business needs."
+          "description": "Design intuitive experiences that solve user needs rather than wants."
         },
         "dataDriven": {
           "title": "Data-Driven",
-          "description": "Leverage SQL, analytics, and adoption metrics to validate decisions and measure impact."
+          "description": "Ditching the vanity metrics, leverage SQL and product analytics to validate decisions."
         },
         "iterative": {
           "title": "Iterative",
-          "description": "Ship MVPs, gather feedback, and improve through agile rituals and cross-functional sprints."
+          "description": "Ship MVPs, observe behaviour, gather feedback, and improve through agile rituals and cross-functional sprints."
         }
       },
       "highlights": {
-        "majorLaunches": "Sandbox Console, GST APIs, Qpon engine, Cliq affiliate platform",
-        "sideProjects": "AI automation apps, marketing automations with n8n and Google Scripts"
+        "majorLaunches": "Console, GST APIs, Qpon coupon engine, Cliq affiliate platform",
+        "sideProjects": "Vibecoded apps & automations with n8n"
       }
     }
   },
   "seo": {
     "title": "Vaibhav Bansal - Product Manager Portfolio",
-    "description": "Product Manager with 2+ years building fintech and automation products. View case studies, projects, and professional experience.",
+    "description": "Product Manager with 2+ years building fintech and automation products. View work, side projects, and professional experience.",
     "keywords": [
       "Product Manager",
       "FinTech",
@@ -80,12 +80,12 @@
       "href": "/about"
     },
     {
-      "name": "Case Studies",
-      "href": "/case-studies"
+      "name": "Work Projects",
+      "href": "/work-projects"
     },
     {
-      "name": "Projects",
-      "href": "/maker-projects"
+      "name": "Side Projects",
+      "href": "/side-projects"
     },
     // {
     //   "name": "Writing",
@@ -114,10 +114,10 @@
       "Postman",
       "JavaScript",
       "Google Analytics",
-      "NoSQL"
+      "Google Tag Manager"
     ],
     "design": [
-      "Figma",
+      "Figjam",
       "Wireframing",
       "Whimsical",
       "System Design"
@@ -132,27 +132,27 @@
   "caseStudies": [
     {
       "id": "sandbox-console",
-      "title": "Sandbox Console Redesign",
-      "subtitle": "Reducing onboarding-to-activation from 2 weeks to 3 days",
+      "title": "Sandbox Console",
+      "subtitle": "Self-serve billing and subscription management console",
       "description": "Launched a self-serve billing and subscription management console, consolidating API keys, usage analytics, team roles, wallet, and billing in one place.",
       "image": "/images/case-study-sandbox.jpg",
       "imageAlt": "Screenshot of Sandbox Console dashboard",
       "tags": [
         "FinTech",
-        "APIs",
-        "Self-Serve"
+        "Subscription",
+        "Onboarding"
       ],
       "duration": "4 months",
-      "team": "Designer, 2 Engineers, QA",
+      "team": "Designer, 2 Engineers",
       "role": "Product Manager",
       "comingSoon": false,
       "impact": {
-        "activationTime": "-85% (2 weeks → 3 days)",
-        "adoption": "100+ API-first clients onboarded",
-        "revenue": "20%+ of annual Sandbox revenue"
+        "activationTime": "-85%",
+        "leads": "3x",
+        "conversionRate": "20%+"
       },
       "content": {
-        "context": "Quicko’s API Sandbox platform required a modernized console to enable developers and businesses to manage subscriptions and usage without support intervention.",
+        "context": "Quicko's API Sandbox platform required a modernized console to enable developers and businesses to manage subscriptions and usage without support intervention.",
         "problem": "How can we reduce time-to-value for new customers and empower them with self-serve tools?",
         "process": [
           {
@@ -248,7 +248,7 @@
         "partnerTiers": "Dynamic tiers & triggers"
       },
       "content": {
-        "context": "The legacy affiliate system lacked scalability and configurability for expanding Quicko’s partner ecosystem.",
+        "context": "The legacy affiliate system lacked scalability and configurability for expanding Quicko's partner ecosystem.",
         "problem": "How might we rebuild Cliq to handle partner scaling, diverse commission rules, and transparent reporting?",
         "process": [
           {
@@ -294,7 +294,7 @@
         "adoption": "Marketing & ops teams actively using"
       },
       "content": {
-        "context": "Quicko’s marketing and ops teams faced recurring manual tasks that slowed productivity.",
+        "context": "Quicko's marketing and ops teams faced recurring manual tasks that slowed productivity.",
         "problem": "How might we leverage AI and workflow automation to eliminate repetitive tasks and free up team bandwidth?",
         "process": [
           {

--- a/src/lib/configLoader.ts
+++ b/src/lib/configLoader.ts
@@ -82,3 +82,11 @@ export const resetConfig = () => {
   config = null;
   configError = null;
 };
+
+// Synchronous version for tests (assumes config is already loaded)
+export const getConfigSync = (): PortfolioConfig => {
+  if (!config) {
+    throw new Error('Configuration not loaded. Call loadConfig() first.');
+  }
+  return config;
+};

--- a/src/lib/configValidation.ts
+++ b/src/lib/configValidation.ts
@@ -31,6 +31,7 @@ export interface CaseStudy {
   role?: string;
   impact: Record<string, string>;
   content?: CaseStudyContent;
+  comingSoon?: boolean;
 }
 
 export interface PortfolioConfig {
@@ -45,6 +46,28 @@ export interface PortfolioConfig {
     bio: string;
     yearsExperience: number;
     currentRole: string;
+    domains: string[];
+    metrics: {
+      usersImpacted: string;
+      arpuUplift: string;
+    };
+    background: {
+      intro: string;
+      philosophy: Record<string, {
+        title: string;
+        description: string;
+      }>;
+      highlights: {
+        majorLaunches: string;
+        sideProjects: string;
+      };
+    };
+  };
+  seo: {
+    title: string;
+    description: string;
+    keywords: string[];
+    author: string;
   };
   social: Record<string, string>;
   navigation: Array<{ name: string; href: string }>;

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -40,15 +40,15 @@ const CaseStudies = () => {
           {/* Header */}
           <div className="text-center mb-16">
             <h1 className="text-4xl sm:text-5xl font-bold text-foreground mb-6">
-              Case Studies
+              Work Projects
             </h1>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Deep dives into real product challenges and the strategies I used to solve them. 
-              Each case study includes the full process, artifacts, and measurable impact.
+              Each project includes the full process, artifacts, and measurable impact.
             </p>
           </div>
 
-          {/* Case Studies Grid */}
+          {/* Work Projects Grid */}
           <div className="space-y-12">
             {portfolioConfig.caseStudies.map((study, index) => {
               // Show coming soon card if marked as coming soon
@@ -132,7 +132,7 @@ const CaseStudies = () => {
                           <div>{study.team}</div>
                         </div>
                         <Button variant="default" asChild>
-                          <Link to={`/case-studies/${study.id}`}>
+                          <Link to={`/work-projects/${study.id}`}>
                             Read Case Study
                             <ArrowRight className="w-4 h-4 ml-2" />
                           </Link>

--- a/src/pages/CaseStudyDetail.tsx
+++ b/src/pages/CaseStudyDetail.tsx
@@ -46,9 +46,9 @@ const CaseStudyDetail = () => {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-4xl font-bold text-foreground mb-4">Case Study Not Found</h1>
           <Button asChild>
-            <Link to="/case-studies">
+            <Link to="/work-projects">
               <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Case Studies
+              Back to Work Projects
             </Link>
           </Button>
         </div>
@@ -62,9 +62,9 @@ const CaseStudyDetail = () => {
         <div className="max-w-4xl mx-auto">
           {/* Back Button */}
           <Button variant="outline" className="btn-outline mb-8" asChild>
-            <Link to="/case-studies" onClick={() => handleNavigationClick("/case-studies", location.pathname)}>
+            <Link to="/work-projects" onClick={() => handleNavigationClick("/work-projects", location.pathname)}>
               <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Case Studies
+              Back to Work Projects
             </Link>
           </Button>
 
@@ -248,9 +248,9 @@ const CaseStudyDetail = () => {
           {/* Navigation */}
           <div className="flex items-center justify-between mt-20 pt-12 border-t border-border">
             <Button variant="outline" className="btn-outline" asChild>
-              <Link to="/case-studies" onClick={() => handleNavigationClick("/case-studies", location.pathname)}>
+              <Link to="/work-projects" onClick={() => handleNavigationClick("/work-projects", location.pathname)}>
                 <ArrowLeft className="w-4 h-4 mr-2" />
-                All Case Studies
+                All Work Projects
               </Link>
             </Button>
             

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -129,13 +129,13 @@ const Index = () => {
         </div>
       </section>
 
-      {/* Featured Case Studies */}
+      {/* Featured Work Projects */}
       <section className="py-20 lg:py-32 bg-muted/50">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-16">
               <h2 className="text-3xl sm:text-4xl font-bold text-foreground mb-6">
-                Featured Case Studies
+                Featured Work Projects
               </h2>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 Real-world product challenges and the strategies I used to solve them
@@ -176,7 +176,7 @@ const Index = () => {
                             {study.duration} • {study.team}
                           </div>
                           <Button variant="ghost" size="sm" asChild>
-                            <Link to={`/case-studies/${study.id}`}>
+                            <Link to={`/work-projects/${study.id}`}>
                               <ArrowRight className="w-4 h-4" />
                             </Link>
                           </Button>
@@ -190,8 +190,8 @@ const Index = () => {
 
             <div className="text-center">
               <Button size="lg" variant="outline" asChild>
-                <Link to="/case-studies" onClick={() => handleNavigationClick("/case-studies", location.pathname)}>
-                  View All Case Studies
+                <Link to="/work-projects" onClick={() => handleNavigationClick("/work-projects", location.pathname)}>
+                  View All Work Projects
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Link>
               </Button>
@@ -200,7 +200,7 @@ const Index = () => {
         </div>
       </section>
 
-      {/* Maker Projects Preview */}
+      {/* Side Projects Preview */}
       <section className="py-20 lg:py-32">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-6xl mx-auto">
@@ -264,7 +264,7 @@ const Index = () => {
                       <div className="grid grid-cols-3 gap-4 text-center">
                         {Object.entries(project.stats).map(([key, value]) => (
                           <div key={key}>
-                            <div className="text-sm font-medium text-primary">{value}</div>
+                            <div className="text-sm font-medium text-primary">{value as React.ReactNode}</div>
                             <div className="text-xs text-muted-foreground capitalize">
                               {key}
                             </div>
@@ -279,8 +279,8 @@ const Index = () => {
 
             <div className="text-center">
               <Button size="lg" variant="outline" asChild>
-                <Link to="/maker-projects" onClick={() => handleNavigationClick("/maker-projects", location.pathname)}>
-                  View All Projects
+                <Link to="/side-projects" onClick={() => handleNavigationClick("/side-projects", location.pathname)}>
+                  View All Side Projects
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Link>
               </Button>

--- a/src/pages/MakerProjects.tsx
+++ b/src/pages/MakerProjects.tsx
@@ -40,7 +40,7 @@ const MakerProjects = () => {
           {/* Header */}
           <div className="text-center mb-16">
             <h1 className="text-4xl sm:text-5xl font-bold text-foreground mb-6">
-              Maker Projects
+              Side Projects
             </h1>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Personal projects where I explore new ideas, experiment with emerging technologies, 
@@ -49,7 +49,7 @@ const MakerProjects = () => {
             </p>
           </div>
 
-          {/* Projects Grid */}
+          {/* Side Projects Grid */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-16">
             {portfolioConfig.makerProjects.map((project) => {
               // Show coming soon card if marked as coming soon
@@ -131,7 +131,7 @@ const MakerProjects = () => {
                       {Object.entries(project.stats).map(([key, value]) => (
                         <div key={key} className="text-center">
                           <div className="text-lg font-bold text-primary mb-1">
-                            {value}
+                            {value as React.ReactNode}
                           </div>
                           <div className="text-xs text-muted-foreground capitalize">
                             {key}
@@ -142,7 +142,7 @@ const MakerProjects = () => {
 
                     {/* CTA */}
                     <Button variant="outline" className="w-full" asChild>
-                      <Link to={`/maker-projects/${project.id}`}>
+                      <Link to={`/side-projects/${project.id}`}>
                         Learn More
                         <ArrowRight className="w-4 h-4 ml-2" />
                       </Link>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -43,9 +43,9 @@ const ProjectDetail = () => {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-4xl font-bold text-foreground mb-4">Project Not Found</h1>
           <Button asChild>
-            <Link to="/maker-projects">
+            <Link to="/side-projects">
               <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Projects
+              Back to Side Projects
             </Link>
           </Button>
         </div>
@@ -59,9 +59,9 @@ const ProjectDetail = () => {
         <div className="max-w-4xl mx-auto">
           {/* Back Button */}
           <Button variant="ghost" className="mb-8" asChild>
-            <Link to="/maker-projects" onClick={() => handleNavigationClick("/maker-projects", location.pathname)}>
+            <Link to="/side-projects" onClick={() => handleNavigationClick("/side-projects", location.pathname)}>
               <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Projects
+              Back to Side Projects
             </Link>
           </Button>
 
@@ -117,7 +117,7 @@ const ProjectDetail = () => {
             <div className="grid grid-cols-3 gap-6">
               {Object.entries(project.stats).map(([key, value]) => (
                 <div key={key} className="text-center p-4 bg-muted/50 rounded-lg">
-                  <div className="text-2xl font-bold text-primary mb-1">{value}</div>
+                  <div className="text-2xl font-bold text-primary mb-1">{value as React.ReactNode}</div>
                   <div className="text-sm text-muted-foreground capitalize">
                     {key}
                   </div>
@@ -294,9 +294,9 @@ const ProjectDetail = () => {
           {/* Navigation */}
           <div className="flex items-center justify-between mt-20 pt-12 border-t border-border">
             <Button variant="outline" asChild>
-              <Link to="/maker-projects" onClick={() => handleNavigationClick("/maker-projects", location.pathname)}>
+              <Link to="/side-projects" onClick={() => handleNavigationClick("/side-projects", location.pathname)}>
                 <ArrowLeft className="w-4 h-4 mr-2" />
-                All Projects
+                All Side Projects
               </Link>
             </Button>
             


### PR DESCRIPTION
- Updated navigation and routing throughout the application
- Changed routes from /work to /work-projects and /maker-projects to /side-projects
- Updated all page titles, buttons, and internal links
- Fixed TypeScript errors and updated interface definitions
- Updated test files to reflect new naming convention
- Enhanced PortfolioConfig interface with missing properties
- All functionality preserved with improved naming clarity